### PR TITLE
stable - Bump Oasis Core to 21.3.13

### DIFF
--- a/.changelog/330.feature.md
+++ b/.changelog/330.feature.md
@@ -1,0 +1,1 @@
+Bump Oasis Core to 21.3.13

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include common.mk
 
-OASIS_RELEASE := 21.3.9
+OASIS_RELEASE := 21.3.13
 ROSETTA_CLI_RELEASE := 0.7.3
 
 # Check which tool to use for downloading.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ FROM golang:1.17-bullseye AS build
 # Install prerequisites.
 RUN apt-get update && apt-get install -y bzip2 libseccomp-dev
 
-ARG CORE_BRANCH=v21.3.9
+ARG CORE_BRANCH=v21.3.13
 ARG CORE_GITHUB=https://github.com/oasisprotocol/oasis-core
 
 ARG GATEWAY_BRANCH=master

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint 
 require (
 	github.com/coinbase/rosetta-cli v0.7.3
 	github.com/coinbase/rosetta-sdk-go v0.7.3
-	github.com/oasisprotocol/oasis-core/go v0.2103.9
+	github.com/oasisprotocol/oasis-core/go v0.2103.13
 	google.golang.org/grpc v1.44.0
 )
 
@@ -50,7 +50,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/neilotoole/errgroup v0.1.6 // indirect
 	github.com/nixberg/chacha-rng-go v0.1.0 // indirect
-	github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 // indirect
+	github.com/oasisprotocol/curve25519-voi v0.0.0-20211219162838-e9a669f65da9 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -971,12 +971,12 @@ github.com/nixberg/chacha-rng-go v0.1.0 h1:2Y90hS8H/O+82yLWKD4MldkJM7Pzhezc7rT6E
 github.com/nixberg/chacha-rng-go v0.1.0/go.mod h1:iPf1i6Vcwgoue86dblORobEXNCd1PFQiysFiImawfCM=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
-github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20211219162838-e9a669f65da9 h1:7PEzI9zayQvzHKpF2HRGlLnhs6RFNnbMAnolyyVevug=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20211219162838-e9a669f65da9/go.mod h1:WUcXjUd98qaCVFb6j8Xc87MsKeMCXDu9Nk8JRJ9SeC8=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
-github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.13 h1:I7ODe5cmMpKzLxVnUWBeP2jaCEy6Rhsms+DrV7ZxjbE=
+github.com/oasisprotocol/oasis-core/go v0.2103.13/go.mod h1:t3VP2KjCwlmUCEKywFLZIBdBHNzHhVUjwIPjUqD+urk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2/go.mod h1:agEnj5cjmg55z8CtL/Nva9LqxR4402T1TFPC4kuNBMc=


### PR DESCRIPTION
21.3.13 has new fields in the status structure. updating the oasis-core module to match