### PR TITLE
account: provide delegations_to instead

### DIFF
--- a/.changelog/348.breaking.md
+++ b/.changelog/348.breaking.md
@@ -1,0 +1,5 @@
+account: provide delegations_to instead
+
+oasis-node does not handle GetDelegations efficiently. This changes
+the gateway to use GetDelegationsTo, which the node can answer
+efficiently.

--- a/oasis/oasis.go
+++ b/oasis/oasis.go
@@ -49,9 +49,9 @@ type Client interface {
 	// at given height.
 	GetAccount(ctx context.Context, height int64, owner staking.Address) (*staking.Account, error)
 
-	// GetDelegations returns the staking active delegations where the given
-	// owner address is the delegator, as of given height.
-	GetDelegations(
+	// GetDelegationsTo returns the staking active delegations where the given
+	// owner address is the validator, as of given height.
+	GetDelegationsTo(
 		ctx context.Context, height int64, owner staking.Address,
 	) (map[staking.Address]*staking.Delegation, error)
 
@@ -246,7 +246,7 @@ func (c *grpcClient) GetAccount(ctx context.Context, height int64, owner staking
 	})
 }
 
-func (c *grpcClient) GetDelegations(
+func (c *grpcClient) GetDelegationsTo(
 	ctx context.Context,
 	height int64,
 	owner staking.Address,
@@ -256,7 +256,7 @@ func (c *grpcClient) GetDelegations(
 		return nil, err
 	}
 	client := staking.NewStakingClient(conn)
-	return client.DelegationsFor(ctx, &staking.OwnerQuery{
+	return client.DelegationsTo(ctx, &staking.OwnerQuery{
 		Height: height,
 		Owner:  owner,
 	})

--- a/services/account.go
+++ b/services/account.go
@@ -40,11 +40,11 @@ const DebondingBalanceKey = "debonding_balance"
 // the debonding escrow pool.
 const DebondingSharesKey = "debonding_shares"
 
-// DelegationsKey is the name of the key in the Metadata map inside
+// DelegationsToKey is the name of the key in the Metadata map inside
 // the response of an account balance request for an escrow account.
-// The value in the Metadata map is the response from a GetDelegations
+// The value in the Metadata map is the response from a GetDelegationsTo
 // call.
-const DelegationsKey = "delegations"
+const DelegationsToKey = "delegations_to"
 
 // DebondingDelegationsKey is the name of the key in the Metadata map inside
 // the response of an account balance request for an escrow account.
@@ -148,16 +148,16 @@ func (s *accountAPIService) AccountBalance(
 		md[DebondingBalanceKey] = act.Escrow.Debonding.Balance.String()
 		md[DebondingSharesKey] = act.Escrow.Debonding.TotalShares.String()
 
-		delegations, err := s.oasisClient.GetDelegations(ctx, height, owner)
+		delegationsTo, err := s.oasisClient.GetDelegationsTo(ctx, height, owner)
 		if err != nil {
-			loggerAcct.Error("AccountBalance: unable to get delegations",
+			loggerAcct.Error("AccountBalance: unable to get delegations to",
 				"account_id", owner.String(),
 				"height", height,
 				"err", err,
 			)
 			return nil, ErrUnableToGetAccount
 		}
-		md[DelegationsKey] = delegations
+		md[DelegationsToKey] = delegationsTo
 		debondingDelegations, err := s.oasisClient.GetDebondingDelegations(ctx, height, owner)
 		if err != nil {
 			loggerAcct.Error("AccountBalance: unable to get debonding delegations",


### PR DESCRIPTION
oasis-node does not handle GetDelegations efficiently. This changes
the gateway to use GetDelegationsTo, which the node can answer
efficiently.

---

ok and from #61/#62, it seems we didn't specifically want delegations from, and the issue looks like it was written to call for either of them. at this point, we know that the node software can much more easily list delegations to an account and debonding delegations "from" an account, so I'm proposing that we move to those.

for users relying on the previous delegations "from" behavior, you'll have to stay on the 2.x.x stable branches, and we should maintain that for some amount of time.

I intend for us to upgrade any of our own deployments to include this change.

fixes #347 