### PR TITLE
Assemble changes for 2.5.0 release

### DIFF
--- a/.changelog/444.internal.md
+++ b/.changelog/444.internal.md
@@ -1,1 +1,0 @@
-ci: bump golangci/golangci-lint-action from 3.4.0 to 3.6.0

--- a/.changelog/445.internal.md
+++ b/.changelog/445.internal.md
@@ -1,1 +1,0 @@
-ci: bump docker/build-push-action from 4.0.0 to 4.1.1

--- a/.changelog/449.internal.go
+++ b/.changelog/449.internal.go
@@ -1,1 +1,0 @@
-ci: bump actions/setup-node from 3.6.0 to 3.7.0

--- a/.changelog/451.internal.md
+++ b/.changelog/451.internal.md
@@ -1,1 +1,0 @@
-ci: bump actions/setup-python from 4.6.0 to 4.7.0

--- a/.changelog/452.internal.md
+++ b/.changelog/452.internal.md
@@ -1,1 +1,0 @@
-go: bump google.golang.org/grpc from 1.55.0 to 1.57.0

--- a/.changelog/455.feature.md
+++ b/.changelog/455.feature.md
@@ -1,1 +1,0 @@
-Bump Oasis Core to 22.2.11

--- a/.punch_version.py
+++ b/.punch_version.py
@@ -1,3 +1,3 @@
 major = 2
-minor = 4
+minor = 5
 patch = 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,35 @@ The format is inspired by [Keep a Changelog].
 
 <!-- TOWNCRIER -->
 
+## 2.5.0 (2023-08-11)
+
+| Name         | Version |
+|:-------------|:-------:|
+| Rosetta API  | 1.4.12  |
+| Oasis Core   | 22.2.11 |
+
+### Features
+
+- Bump Oasis Core to 22.2.11
+  ([#455](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/455))
+
+### Internal Changes
+
+- ci: bump golangci/golangci-lint-action from 3.4.0 to 3.6.0
+  ([#444](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/444))
+
+- ci: bump docker/build-push-action from 4.0.0 to 4.1.1
+  ([#445](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/445))
+
+- ci: bump actions/setup-node from 3.6.0 to 3.7.0
+  ([#449](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/449))
+
+- ci: bump actions/setup-python from 4.6.0 to 4.7.0
+  ([#451](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/451))
+
+- go: bump google.golang.org/grpc from 1.55.0 to 1.57.0
+  ([#452](https://github.com/oasisprotocol/oasis-rosetta-gateway/issues/452))
+
 ## 2.4.0 (2023-05-18)
 
 | Name         | Version |


### PR DESCRIPTION
this is for us to release a docker image with oasis-core 22.2.11