### PR TITLE
docs: updates

### DIFF
--- a/.changelog/487.doc.md
+++ b/.changelog/487.doc.md
@@ -1,0 +1,1 @@
+docs: update links and node directories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ The format is inspired by [Keep a Changelog].
 
   <!-- markdownlint-disable line-length -->
   The Rosetta ecosystem prefers this:
-  [Rosetta's guidance on Docker deployment](https://www.rosetta-api.org/docs/node_deployment.html#ubuntu-image-compatibility).
+  [Rosetta's guidance on Docker deployment](https://docs.cloud.coinbase.com/rosetta/docs/docker-deployment#ubuntu-image-compatibility).
   <!-- markdownlint-enable line-length -->
 
 - docker: Skip running node if offline var is set

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ See the [Rosetta API] docs for information on how to use the API.
 Oasis-specific Rosetta API information is given in the
 [Oasis-specific Information] subsection below.
 
-[Rosetta]: https://www.rosetta-api.org/
+[Rosetta]: https://docs.cloud.coinbase.com/rosetta/docs/welcome
 [Oasis Network]: https://docs.oasis.io/general/oasis-network/
-[Rosetta API]: https://www.rosetta-api.org/docs/welcome.html
+[Rosetta API]: https://docs.cloud.coinbase.com/rosetta/docs/welcome
 [Oasis-specific Information]: #oasis-specific-information
 
 ## Building and Testing
@@ -106,7 +106,7 @@ The only supported endpoints in offline mode are:
 ```
 
 [Construction API]:
-  https://www.rosetta-api.org/docs/construction_api_introduction.html
+  https://docs.cloud.coinbase.com/rosetta/docs/construction-api-overview
 [genesis document's hash]:
   https://docs.oasis.io/core/consensus/genesis#genesis-documents-hash
 
@@ -118,7 +118,7 @@ This section describes how Oasis fits into the Rosetta APIs.
 
 [Rosetta API documentation][api-network-identifier]
 
-[api-network-identifier]: https://www.rosetta-api.org/docs/api_identifiers.html#network-identifier
+[api-network-identifier]: https://docs.cloud.coinbase.com/rosetta/docs/identifiers#network-identifier
 
 For Amber (at time of writing):
 
@@ -137,7 +137,7 @@ hex encoded SHA-512/256 hash of the CBOR encoded genesis document.
 
 [Rosetta API documentation][api-account-identifier]
 
-[api-account-identifier]: https://www.rosetta-api.org/docs/api_identifiers.html#account-identifier
+[api-account-identifier]: https://docs.cloud.coinbase.com/rosetta/docs/identifiers#account-identifier
 
 #### General Account
 
@@ -196,7 +196,7 @@ For the fee accumulator:
 
 [Rosetta API documentation][api-currency]
 
-[api-currency]: https://www.rosetta-api.org/docs/api_objects.html#currency
+[api-currency]: https://docs.cloud.coinbase.com/rosetta/docs/objects#currency
 
 #### ROSE
 
@@ -217,9 +217,9 @@ Rosetta API documentation on
 [/construction/payloads][api-constructionpayloads].
 
 [api-constructionpreprocess]:
-    https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpreprocess
+  https://docs.cloud.coinbase.com/rosetta/reference/constructionpreprocess
 [api-constructionpayloads]:
-    https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpayloads
+  https://docs.cloud.coinbase.com/rosetta/reference/constructionpayloads
 
 The first two operations in the listings are the gas fee payment.
 For zero-fee transactions, omit them and decrease the remaining operation
@@ -676,14 +676,14 @@ transaction's intent:
 * The `metadata` field is absent.
 
 [api-block]:
-  https://www.rosetta-api.org/docs/BlockApi.html#block
+  https://docs.cloud.coinbase.com/rosetta/reference/block
 [partial block identifier]:
-  https://www.rosetta-api.org/docs/models/PartialBlockIdentifier.html
+  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#identifiers
 [block response]:
-  https://www.rosetta-api.org/docs/models/BlockResponse.html
+  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#requests-and-responses
 [block]:
-  https://www.rosetta-api.org/docs/models/Block.html
+  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects
 [transaction]:
-  https://www.rosetta-api.org/docs/models/Transaction.html
+  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects
 [operation]:
-  https://www.rosetta-api.org/docs/models/Operation.html
+  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Oasis-specific Rosetta API information is given in the
 [Oasis-specific Information] subsection below.
 
 [Rosetta]: https://www.rosetta-api.org/
-[Oasis Network]: https://docs.oasis.dev/general/oasis-network/overview
+[Oasis Network]: https://docs.oasis.io/general/oasis-network/
 [Rosetta API]: https://www.rosetta-api.org/docs/welcome.html
 [Oasis-specific Information]: #oasis-specific-information
 
@@ -49,7 +49,7 @@ make clean
 [Rosetta CLI], set up a test Oasis network, make some sample transactions,
 then run the gateway and validate it using `rosetta-cli`.
 
-[Oasis Node]: https://docs.oasis.dev/general/run-a-node/prerequisites/oasis-node
+[Oasis Node]: https://docs.oasis.io/node/run-your-node/prerequisites/oasis-node/
 [Rosetta CLI]: https://github.com/coinbase/rosetta-cli
 
 ## Contributing
@@ -69,8 +69,8 @@ See our [Release Process] document.
 ## Running the Gateway
 
 The gateway connects to an Oasis Node, so make sure you have a running node
-first. For more details, see the [Run a Non-validator Node] doc of the general
-[Oasis Docs].
+first. For more details, see the [Run a Non-validator Node] doc of the
+[Run Node Oasis Docs].
 
 Set the `OASIS_NODE_GRPC_ADDR` environment variable to the node's gRPC socket
 address (e.g. `unix:/path/to/node/internal.sock`).
@@ -81,9 +81,9 @@ port that you want the gateway to listen on (default is 8080).
 Start the gateway simply by running the executable `oasis-rosetta-gateway`.
 
 [Run a Non-validator Node]:
-  https://docs.oasis.dev/general/run-a-node/set-up-your-node/run-non-validator#configuration
-[Oasis Docs]:
-  https://docs.oasis.dev/
+  https://docs.oasis.io/node/run-your-node/non-validator-node/#configuration
+[Run Node Oasis Docs]:
+  https://docs.oasis.io/node/
 
 ## Offline Mode
 
@@ -108,7 +108,7 @@ The only supported endpoints in offline mode are:
 [Construction API]:
   https://www.rosetta-api.org/docs/construction_api_introduction.html
 [genesis document's hash]:
-  https://docs.oasis.dev/oasis-core/high-level-components/index/genesis#genesis-documents-hash
+  https://docs.oasis.io/core/consensus/genesis#genesis-documents-hash
 
 ## Oasis-specific Information
 

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,5 +1,5 @@
 # Ignore everything to prevent accidentally copying any files from the context
 # directory.
 # NOTE: This is a requirement for Rosetta API Docker Deployment:
-# https://www.rosetta-api.org/docs/node_deployment.html#build-anywhere
+# https://docs.cloud.coinbase.com/rosetta/docs/docker-deployment#build-anywhere
 **/*

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,14 +50,14 @@ build  image to save disk space.
   https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/
 [Change Log for 1.1.1]:
   https://github.com/oasisprotocol/oasis-rosetta-gateway/blob/v1.1.1/CHANGELOG.md
-[Rosetta API]: https://www.rosetta-api.org/docs/welcome.html
+[Rosetta API]: https://docs.cloud.coinbase.com/rosetta/docs/welcome
 [Oasis Core]: https://github.com/oasisprotocol/oasis-core
 [Oasis Node]:
   https://docs.oasis.io/node/run-your-node/prerequisites/oasis-node/
 [Oasis Rosetta Gateway]:
   https://github.com/oasisprotocol/oasis-rosetta-gateway
 [Rosetta Docker Deployment]:
-  https://www.rosetta-api.org/docs/node_deployment.html
+  https://docs.cloud.coinbase.com/rosetta/docs/docker-deployment
 [Run a Non-validator Node]:
   https://docs.oasis.io/node/run-your-node/non-validator-node/#configuration
 [Run Node Oasis Docs]:

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,9 @@ the [Oasis Node] and the [Oasis Rosetta gateway], as instructed by the
 The node should be configured as described in [Run a Non-validator Node] doc
 of the general [Oasis Docs].
 
-The `/node` directory in the instructions is equivalent to the `/data`
+The `/node/data` directory in the instructions is equivalent to the `/data`
+directory of the Docker image.
+The `/node/etc` directory in the instructions is equivalent to the `/data/etc`
 directory of the Docker image.
 We recommend creating a volume mount for `/data` so that you can manage the
 directory across version upgrades.

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ the [Oasis Node] and the [Oasis Rosetta gateway], as instructed by the
 [Rosetta Docker Deployment] doc.
 
 The node should be configured as described in [Run a Non-validator Node] doc
-of the general [Oasis Docs].
+of the [Run Node Oasis Docs].
 
 The `/node/data` directory in the instructions is equivalent to the `/data`
 directory of the Docker image.
@@ -53,13 +53,13 @@ build  image to save disk space.
 [Rosetta API]: https://www.rosetta-api.org/docs/welcome.html
 [Oasis Core]: https://github.com/oasisprotocol/oasis-core
 [Oasis Node]:
-  https://docs.oasis.dev/general/run-a-node/prerequisites/oasis-node
+  https://docs.oasis.io/node/run-your-node/prerequisites/oasis-node/
 [Oasis Rosetta Gateway]:
   https://github.com/oasisprotocol/oasis-rosetta-gateway
 [Rosetta Docker Deployment]:
   https://www.rosetta-api.org/docs/node_deployment.html
 [Run a Non-validator Node]:
-  https://docs.oasis.dev/general/run-a-node/set-up-your-node/run-non-validator#configuration
-[Oasis Docs]:
-  https://docs.oasis.dev/
+  https://docs.oasis.io/node/run-your-node/non-validator-node/#configuration
+[Run Node Oasis Docs]:
+  https://docs.oasis.io/node/
 <!-- markdownlint-enable line-length -->

--- a/services/account.go
+++ b/services/account.go
@@ -198,8 +198,9 @@ func (s *accountAPIService) AccountCoins(
 	ctx context.Context,
 	request *types.AccountCoinsRequest,
 ) (*types.AccountCoinsResponse, *types.Error) {
-	// https://www.rosetta-api.org/docs/AccountApi.html#accountcoins
-	// If your implementation does not support coins (i.e. it is for an account-based blockchain), you do not need to
-	// implement this endpoint.
+	// https://docs.cloud.coinbase.com/rosetta/reference/accountcoins
+	// > If your implementation does not support coins (i.e. it is for an
+	// > account-based blockchain), you do not need to implement this
+	// > endpoint.
 	return nil, ErrNotImplemented
 }

--- a/services/construction.go
+++ b/services/construction.go
@@ -1,4 +1,4 @@
-// https://www.rosetta-api.org/docs/construction_api_introduction.html
+// https://docs.cloud.coinbase.com/rosetta/docs/construction-api-overview
 package services
 
 import (


### PR DESCRIPTION
- @gw0 pointed out that docs now recommend /node/data and /node/etc. here's at least an explanation of what we do differently
- all of our links now redirect, so I went through
- omg rosetta's website is moving, and they no longer have api structure reference