### PR TITLE
tests: rosetta -> mesh

### DIFF
--- a/.changelog/507.internal.md
+++ b/.changelog/507.internal.md
@@ -1,0 +1,1 @@
+tests: rosetta -> mesh

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tests/oasis-net-runner
 tests/oasis-node
 tests/oasis_core_release.tar.gz
 tests/oasis-core
+tests/mesh-cli*
 tests/rosetta-cli*
 tests/validator-data
 # Ignore Python cache directories.

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ tests/rosetta-cli.tar.gz:
 tests/rosetta-cli: tests/rosetta-cli.tar.gz
 	@$(ECHO) "$(MAGENTA)*** Building rosetta-cli...$(OFF)"
 	@tar -xf $< -C tests
-	@cd tests/rosetta-cli-$(ROSETTA_CLI_RELEASE) && $(GO) build
-	@cp tests/rosetta-cli-$(ROSETTA_CLI_RELEASE)/rosetta-cli tests/.
+	@cd tests/mesh-cli-$(ROSETTA_CLI_RELEASE) && $(GO) build
+	@cp tests/mesh-cli-$(ROSETTA_CLI_RELEASE)/rosetta-cli tests/.
 
 test: build build-tests tests/oasis-net-runner tests/oasis-node tests/rosetta-cli
 	@$(ECHO) "$(CYAN)*** Running tests...$(OFF)"


### PR DESCRIPTION
Coinbase has silently renamed Rosetta-related repos to "mesh." Here's a patch to fix our build.
No further renaming until they at least acknowledge the renaming.