### PR TITLE
docs: restore specific model refrence links

### DIFF
--- a/.changelog/524.doc.md
+++ b/.changelog/524.doc.md
@@ -1,0 +1,1 @@
+docs: restore specific model refrence links

--- a/README.md
+++ b/README.md
@@ -678,12 +678,12 @@ transaction's intent:
 [api-block]:
   https://docs.cloud.coinbase.com/rosetta/reference/block
 [partial block identifier]:
-  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#identifiers
+  https://docs.cloud.coinbase.com/rosetta/docs/models#partialblockidentifier
 [block response]:
-  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#requests-and-responses
+  https://docs.cloud.coinbase.com/rosetta/docs/models#blockresponse
 [block]:
-  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects
+  https://docs.cloud.coinbase.com/rosetta/docs/models#block
 [transaction]:
-  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects
+  https://docs.cloud.coinbase.com/rosetta/docs/models#transaction
 [operation]:
-  https://docs.cloud.coinbase.com/rosetta/docs/full-reference#objects
+  https://docs.cloud.coinbase.com/rosetta/docs/models#operation


### PR DESCRIPTION
they reinstated these in their new docs site