### PR TITLE
CI: fix command injection plus other changes

### DIFF
--- a/.changelog/527.internal.md
+++ b/.changelog/527.internal.md
@@ -1,0 +1,1 @@
+CI: fix command injection plus other changes

--- a/.github/workflows/ci-dependabot.yml
+++ b/.github/workflows/ci-dependabot.yml
@@ -49,4 +49,4 @@ jobs:
           git commit --amend --no-edit
       - name: Push changes back to branch
         run: |
-          git push --force-with-lease origin HEAD:refs/heads/${{ github.head_ref }}
+          git push --force-with-lease origin "HEAD:refs/heads/$GITHUB_HEAD_REF"

--- a/.github/workflows/ci-dependabot.yml
+++ b/.github/workflows/ci-dependabot.yml
@@ -33,8 +33,13 @@ jobs:
         run: |
           echo "FILE_NAME=.changelog/${{ github.event.pull_request.number }}.internal.md" >> $GITHUB_OUTPUT
       - name: Create Change Log file
+        env:
+          # There's no support for escaping this for use in a shell command.
+          # GitHub's recommendation is to pass it through the environment.
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo ${{ github.event.pull_request.title }} > ${{ steps.vars.outputs.FILE_NAME }}
+          echo "$TITLE" > ${{ steps.vars.outputs.FILE_NAME }}
       - name: Commit Change Log file
         run: |
           # Set git user email and name to match author of the last commit.

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -57,10 +57,8 @@ jobs:
         # is able to compare the current branch with the base branch.
         # Source: https://github.com/actions/checkout/#fetch-all-branches.
         run: |
-          git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
-          towncrier check --compare-with origin/${BASE_BRANCH}
-        env:
-          BASE_BRANCH: ${{ github.base_ref }}
+          git fetch --no-tags origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          towncrier check --compare-with "origin/${GITHUB_BASE_REF}"
         if: github.event_name == 'pull_request'
       - name: Lint git commits
         run: |


### PR DESCRIPTION
- command injection through PR title
- switch over to shell variable substitution in certain places that used command string interpolation
- switch to a default environment variable https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables in a place where we defined our own